### PR TITLE
updating the My skill component i removed the 01,02,03

### DIFF
--- a/src/scenes/MySkills.jsx
+++ b/src/scenes/MySkills.jsx
@@ -71,7 +71,6 @@ const MySkills = () => {
         >
           <div className="relative h-32">
             <div className="z-10">
-              <p className="font-playfair font-semibold text-5xl">01</p>
               <p className="font-playfair font-semibold text-3xl mt-3">
                 Experience
               </p>
@@ -101,7 +100,6 @@ const MySkills = () => {
         >
           <div className="relative h-32">
             <div className="z-10">
-              <p className="font-playfair font-semibold text-5xl">02</p>
               <p className="font-playfair font-semibold text-3xl mt-3">
                 Innovative
               </p>
@@ -127,7 +125,6 @@ const MySkills = () => {
         >
           <div className="relative h-32">
             <div className="z-10">
-              <p className="font-playfair font-semibold text-5xl">03</p>
               <p className="font-playfair font-semibold text-3xl mt-3">
                 Imaginative
               </p>


### PR DESCRIPTION
# My Skills Component Update

## Description
This update enhances the `My Skills` component by removing unnecessary numerical prefixes (e.g., `01`, `02`, `03`) and providing a clearer, more concise presentation of skills and experience. Additionally, the skill list was restructured into a more detailed format to better showcase the technologies and expertise areas.

## Features Updated
1. **Removed Numerical Prefixes**:
   - The prefixes such as `01`, `02`, `03` have been removed from section titles for a cleaner and more professional design.

2. **Skills Section Restructure**:
   - Reorganized the skills into categorized lists to clearly highlight specific technical proficiencies.

3. **Experience Section Update**:
   - Added detailed descriptions of roles and responsibilities:
     - **Junior Software Developer**: Focus on full-stack development.
     - **Remote Instructor, The Last Mile.org**: Teaching introductory software development and Full-Stack MERN development.

4. **Improved Descriptions**:
   - Updated text in "Innovative" and "Imaginative" sections to better articulate professional skills and teaching philosophy.

## Code Changes Summary

### Original Section with Numerical Prefixes
Previously, section headers included numerical prefixes, such as:
```jsx
<p className="font-playfair font-semibold text-3xl">01. Experience</p>